### PR TITLE
Regression test updates

### DIFF
--- a/tests/regression_test.py
+++ b/tests/regression_test.py
@@ -36,29 +36,29 @@ class RegressionTest():
 
     def jensen_jimenez_baseline(self, turbine_index):
         baseline = [
-            (0.4632705, 0.7655827, 1793661.6494182, 0.2579167, 7.9736329),
-            (0.4632705, 0.7655827, 1793661.6494182, 0.2579167, 7.9736329)
+            (0.4632706, 0.7655828, 1793661.6494183, 0.2579167, 7.9736330),
+            (0.4553179, 0.8273480,  807133.4600243, 0.2922430, 6.1456034)
         ]
         return baseline[turbine_index]
 
     def floris_jimenez_baseline(self, turbine_index):
         baseline = [
-            (0.4632705, 0.7655827, 1793661.6494182, 0.2579167, 7.9736329),
-            (0.4632705, 0.7655827, 1793661.6494182, 0.2579167, 7.9736329)
+            (0.4632706, 0.7655828, 1793661.6494183, 0.2579167, 7.9736330),
+            (0.4393791, 0.8699828,  510284.5989879, 0.3197105, 5.3375917)
         ]
         return baseline[turbine_index]
 
     def gauss_baseline(self, turbine_index):
         baseline = [
-            (0.4632705, 0.7655827, 1793661.6494182, 0.2579167, 7.9736329),
-            (0.4629500, 0.7741939, 1489994.2682055, 0.2624047, 7.4972929)
+            (0.4632706, 0.7655828, 1793661.6494183, 0.2579167, 7.9736330),
+            (0.4513828, 0.8425381,  679100.2574472, 0.3015926, 5.8185835)
         ]
         return baseline[turbine_index]
 
     def curl_baseline(self, turbine_index):
         baseline = [
-            (0.4632707, 0.7655868, 1793046.5944260, 0.2579188, 7.9727207),
-            (0.4632722, 0.7656358, 1785632.3906150, 0.2579441, 7.9617077)
+            (0.4632707, 0.7655868, 1793046.5944261, 0.2579188, 7.9727208),
+            (0.4577105, 0.8181123,  892703.0087349, 0.2867585, 6.3444362)
         ]
         return baseline[turbine_index]
 
@@ -74,7 +74,7 @@ def test_regression_jensen_jimenez():
     floris = Floris(input_dict=test_class.input_dict)
     floris.farm.flow_field.calculate_wake()
     for i, turbine in enumerate(floris.farm.turbine_map.turbines):
-        # print("({:.17f}, {:.17f}, {:.17f}, {:.17f}, {:.17f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
+        # print("({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
         local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
         assert pytest.approx(local) == test_class.jensen_jimenez_baseline(i)
 
@@ -90,7 +90,7 @@ def test_regression_floris_jimenez():
     floris = Floris(input_dict=test_class.input_dict)
     floris.farm.flow_field.calculate_wake()
     for i, turbine in enumerate(floris.farm.turbine_map.turbines):
-        # print("({:.17f}, {:.17f}, {:.17f}, {:.17f}, {:.17f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
+        # print("({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
         local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
         assert pytest.approx(local) == test_class.floris_jimenez_baseline(i)
 
@@ -105,7 +105,7 @@ def test_regression_gauss():
     floris = Floris(input_dict=test_class.input_dict)
     floris.farm.flow_field.calculate_wake()
     for i, turbine in enumerate(floris.farm.turbine_map.turbines):
-        # print("({:.17f}, {:.17f}, {:.17f}, {:.17f}, {:.17f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
+        # print("({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
         local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
         assert pytest.approx(local) == test_class.gauss_baseline(i)
 
@@ -120,6 +120,57 @@ def test_regression_curl():
     floris = Floris(input_dict=test_class.input_dict)
     floris.farm.flow_field.calculate_wake()
     for i, turbine in enumerate(floris.farm.turbine_map.turbines):
-        # print("({:.17f}, {:.17f}, {:.17f}, {:.17f}, {:.17f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
+        # print("({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
         local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
         assert pytest.approx(local) == test_class.curl_baseline(i)
+
+def test_regression_triangle_farm():
+    """
+    Velocity defecit model: gauss
+    Wake deflection model: gauss
+    Layout: triangle farm where wind direction of 270 and 315 should result in the same power
+    """
+    test_class = RegressionTest()
+    test_class.input_dict["wake"]["properties"]["velocity_model"] = "gauss"
+    test_class.input_dict["wake"]["properties"]["deflection_model"] = "gauss_deflection"
+    distance = 5 * test_class.input_dict["turbine"]["properties"]["rotor_diameter"]
+    test_class.input_dict["farm"]["properties"]["layout_x"] = [0.0, distance, 0.0]
+    test_class.input_dict["farm"]["properties"]["layout_y"] = [distance, distance, 0.0]
+    floris = Floris(input_dict=test_class.input_dict)
+    
+    ### unrotated
+    floris.farm.flow_field.calculate_wake()
+    
+    # turbine 1 - unwaked
+    turbine = floris.farm.turbine_map.turbines[0]
+    local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
+    assert pytest.approx(local) == test_class.gauss_baseline(0)
+
+    # turbine 2 - waked
+    turbine = floris.farm.turbine_map.turbines[1]
+    local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
+    assert pytest.approx(local) == test_class.gauss_baseline(1)
+
+    # turbine 3 - unwaked
+    turbine = floris.farm.turbine_map.turbines[2]
+    local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
+    assert pytest.approx(local) == test_class.gauss_baseline(0)
+    
+    ### rotated
+    floris.farm.flow_field.reinitialize_flow_field(wind_direction=360)
+    floris.calculate_wake()
+
+    # turbine 1 - unwaked
+    turbine = floris.farm.turbine_map.turbines[0]
+    local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
+    assert pytest.approx(local) == test_class.gauss_baseline(0)
+
+    # turbine 2 - unwaked
+    turbine = floris.farm.turbine_map.turbines[1]
+    local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
+    assert pytest.approx(local) == test_class.gauss_baseline(0)
+
+    # turbine 3 - waked
+    turbine = floris.farm.turbine_map.turbines[2]
+    local = (turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity)
+    assert pytest.approx(local) == test_class.gauss_baseline(1)

--- a/tests/sample_inputs.py
+++ b/tests/sample_inputs.py
@@ -18,23 +18,6 @@ class SampleInputs():
     """
 
     def __init__(self):
-        self.farm = {
-            "type": "farm",
-            "name": "farm_example_2x2",
-            "description": "Example 2x2 Wind Farm",
-            "properties": {
-                "wind_speed": 8.0,
-                "wind_direction": 270.0,
-                "turbulence_intensity": 0.1,
-                "wind_shear": 0.12,
-                "wind_veer": 0.0,
-                "air_density": 1.225,
-                "wake_combination": "sosfs",
-                "layout_x": [0.0, 0.0],
-                "layout_y": [0.0, 100.0]
-            }
-        }
-
         self.turbine = {
             "type": "turbine",
             "name": "nrel_5mw",
@@ -54,6 +37,23 @@ class SampleInputs():
                 "yaw_angle": 0.0,
                 "tilt_angle": 0.0,
                 "TSR": 8.0
+            }
+        }
+
+        self.farm = {
+            "type": "farm",
+            "name": "farm_example_2x2",
+            "description": "Example 2x2 Wind Farm",
+            "properties": {
+                "wind_speed": 8.0,
+                "wind_direction": 270.0,
+                "turbulence_intensity": 0.1,
+                "wind_shear": 0.12,
+                "wind_veer": 0.0,
+                "air_density": 1.225,
+                "wake_combination": "sosfs",
+                "layout_x": [0.0, 5 * self.turbine["properties"]["rotor_diameter"]],
+                "layout_y": [0.0, 0.0]
             }
         }
 


### PR DESCRIPTION
This pull request:
- Makes the test layout have a waked turbine
- Updates the baseline solutions based on the new layout (now both turbines dont have the same results)
- Adds the triangular farm test

The previous regression tests had a farm layout with two turbines side by side, not in tandem. Sorry about that! So I've turned the layout 90 degrees and updated the baseline solutions.
The triangular wind farm test is also added. For simplicity in maintaining baseline solutions, I made this layout have two turbine side by side and two in tandem. The rotation is 90 degrees rather than 45, but it should test the same functionality.

@jrannoni please let me know if you have any feedback.